### PR TITLE
Noninteractive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:18.04
 ENV LANG C.UTF-8
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y \
     curl \
     gcc \


### PR DESCRIPTION
Added noninteractive to dockerfile as `apt-get update && apt-get install` sometimes ask for user input:
```
Please select the geographic area in which you live. Subsequent configuration questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.

1. Africa   3. Antarctica  5. Arctic  7. Atlantic  9. Indian    11. SystemV  13. Etc
2. America  4. Australia   6. Asia    8. Europe    10. Pacific  12. US
Geographic area: 
```